### PR TITLE
Fix env assignment formatting in configure script

### DIFF
--- a/configure
+++ b/configure
@@ -8,46 +8,46 @@ installEnv(){
 		echo "telegram config"
 		echo "Entry your token for bot telegram:"
 		read api
-		echo "API_TELEGRAM = $api" >> $FILE
+		echo "API_TELEGRAM=$api" >> $FILE
 
 		echo "Entry name bot telegram exemple @test_bot:"
 		read api
-		echo "BOT_NAME = $api" >> $FILE
+		echo "BOT_NAME=$api" >> $FILE
 
 		echo "Entry your API_ID telegram bot https://my.telegram.org/auth:"
 		read api
-		echo "API_ID = $api" >> $FILE
+		echo "API_ID=$api" >> $FILE
 
 		echo "Entry your API_HASH telegram bot https://my.telegram.org/auth:"
 		read api
-		echo "API_HASH = $api" >> $FILE
+		echo "API_HASH=$api" >> $FILE
 
 		echo "Bybit config"
 		echo "Entry your API bybit:"
 		read api
-		echo "API = $api" >> $FILE
+		echo "API=$api" >> $FILE
 
 		echo "Entry your API_SECRET bybit:"
 		read api
-		echo "API_SECRET = $api" >> $FILE
+		echo "API_SECRET=$api" >> $FILE
 
 		echo "Entry your URL bybit:"
 		read api
-		echo "URL = $api" >> $FILE
+		echo "URL=$api" >> $FILE
 
 		echo "signal channel id exemple 1708830683 or @name_channel"
 		read api
-		echo "SIGNAL_CHANNEL = $api" >> $FILE
+		echo "SIGNAL_CHANNEL=$api" >> $FILE
 
 		echo "Your channel group for share the signal id exemple 1708830683 or @name_channel"
 		read api
-		echo "ID_CHANNEL = $api" >> $FILE
+		echo "ID_CHANNEL=$api" >> $FILE
 
 		echo "MARIADB_ROOT_PWD=test" >> $FILE
 
 		echo "Admin user login"
 		read user
-		echo "ADMIN = $user" >> $FILE
+		echo "ADMIN=$user" >> $FILE
 	fi
 }
 


### PR DESCRIPTION
## Summary
- remove spaces around `=` in configure script's env variable echo statements

## Testing
- `bash -n configure`
- `make test` *(fails: No rule to make target 'test')*
- `shellcheck configure` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bf06d2b4548333aacf5569c98fe2f7